### PR TITLE
[MRG]: Add docs, improve testing

### DIFF
--- a/doc/whats_new.md
+++ b/doc/whats_new.md
@@ -20,11 +20,42 @@ merged into `master`! Use `git log` instead and cross-reference instead. -->
 
 <!-- ### Bug Fixes -->
 
-<!-- ### API Changes -->
+<!-- ### Public API Changes -->
 
 <!-- ### People who contributed to this release (in alphabetical order of family name): -->
 
 <!-- ### Changelog -->
+
+## 0.4.3 in-progress development changes
+
+<!-- ### New Features -->
+
+<!-- ### Deprecations -->
+
+<!-- ### Upcoming Deprecations -->
+
+<!-- ### Bug Fixes -->
+
+### Public API Changes
+
+- {class}`~hnn_core.Network` now accepts optional arguments for its position dictionary  attribute `pos_dict` and cell type dictionary attribute `cell_types`,
+  by [Chetan Kandpal][] in {gh}`1095`.
+
+### People who contributed to this release (in alphabetical order of family name):
+
+- [Chetan Kandpal][]
+
+### Changelog
+
+- Add support for {class}`~hnn_core.Network` to calculate a "layer dictionary"
+  `layer_dict` attribute whose layers can be mapped as desired to an object's
+  `cell_types` attribute. This mapping can then be used to make a more flexible position
+  dictionary `pos_dict` attribute of the object. This also adds support for optional
+  `pos_dict` and `cell_types` arguments to the {class}`~hnn_core.Network`
+  constructor. This also begins the process of moving some model-specific celltype-usage
+  from `network.py` to `network_models.py`. This is the first in a series of code
+  changes meant to allow for more flexible cell types to be used.
+  By [Chetan Kandpal][] in {gh}`1095`.
 
 ## 0.4.2 Patch Notes
 

--- a/hnn_core/network.py
+++ b/hnn_core/network.py
@@ -320,20 +320,28 @@ class Network:
     ----------
     params : dict
         The parameters to use for constructing the network.
-    add_drives_from_params : bool
+    add_drives_from_params : bool, default=False
         If True, add drives as defined in the params-dict. NB this is mainly
         for backward-compatibility with HNN GUI, and will be deprecated in a
-        future release. Default: False
-    legacy_mode : bool
+        future release.
+    legacy_mode : bool, default=False
         Set to True by default to enable matching HNN GUI output when drives
         are added suitably. Will be deprecated in a future release.
     mesh_shape : tuple of int (default: (10, 10))
         Defines the (n_x, n_y) shape of the grid of pyramidal cells.
-
+    pos_dict : dict of list of tuple (x, y, z), optional
+        Dictionary containing the coordinate positions of all cells.
+        Keys are 'L2_pyramidal', 'L5_pyramidal', 'L2_basket', 'L5_basket',
+        or any external drive name.
+    cell_types : dict of Cell, optional
+        Dictionary containing names of real cell types in the network
+        (e.g. 'L2_basket') as keys and corresponding Cell instances as values.
+        The Cell instance associated with a given key is used as a template
+        for the other cells of its type in the population.
 
     Attributes
     ----------
-    cell_types : dict
+    cell_types : dict of Cell
         Dictionary containing names of real cell types in the network
         (e.g. 'L2_basket') as keys and corresponding Cell instances as values.
         The Cell instance associated with a given key is used as a template
@@ -344,10 +352,10 @@ class Network:
         cell_types, followed by keys read from external_drives. The value
         of each key is a range of ints, one for each cell in given category.
         Examples: 'L2_basket': range(0, 270), 'evdist1': range(272, 542), etc
-    pos_dict : dict
+    pos_dict : dict of list of tuple (x, y, z)
         Dictionary containing the coordinate positions of all cells.
         Keys are 'L2_pyramidal', 'L5_pyramidal', 'L2_basket', 'L5_basket',
-        or any external drive name
+        or any external drive name.
     cell_response : CellResponse
         An instance of the CellResponse object.
     external_drives : dict (keys: drive names) of dict (keys: parameters)

--- a/hnn_core/network.py
+++ b/hnn_core/network.py
@@ -39,7 +39,7 @@ def _create_cell_coords(n_pyr_x, n_pyr_y, z_coord, inplane_distance):
         The number of Pyramidal cells in x direction.
     n_pyr_y : int
         The number of Pyramidal cells in y direction.
-    zdiff : float
+    z_coord : float
         Expressed as a positive DEPTH of L2 relative to L5 pyramidal cell
         somas, where L5 is defined to lie at z==0. Interlaminar weight/delay
         calculations (lamtha) are not affected. The basket cells are
@@ -52,10 +52,11 @@ def _create_cell_coords(n_pyr_x, n_pyr_y, z_coord, inplane_distance):
 
     Returns
     -------
-    pos_dict : dict of list of tuple (x, y, z)
-        Dictionary containing coordinate positions.
-        Keys are 'L2_pyramidal', 'L5_pyramidal', 'L2_basket', 'L5_basket',
-        'common', or any of the elements of the list p_unique_keys
+    layer_dict : dict of list of tuple (x, y, z)
+        Dictionary containing coordinate positions of 'layers'. After calling
+        '_create_cell_coords', user can create their 'Network.pos_dict' by mapping
+        'origin' and their celltypes onto the different layers in 'layer_dict'. Keys are
+        'L2_bottom', 'L2_mid', 'L5_bottom', 'L5_mid', and 'origin'.
 
     Notes
     -----

--- a/hnn_core/network_models.py
+++ b/hnn_core/network_models.py
@@ -18,7 +18,6 @@ def jones_2009_model(
     add_drives_from_params=False,
     legacy_mode=False,
     mesh_shape=(10, 10),
-    custom_positions=None,
 ):
     """Instantiate the network model described in Jones et al. 2009 [1]_
 

--- a/hnn_core/tests/test_network.py
+++ b/hnn_core/tests/test_network.py
@@ -1,19 +1,28 @@
 # Authors: Mainak Jas <mainakjas@gmail.com>
 
-from hnn_core.dipole import simulate_dipole
 import os.path as op
+import tempfile
+
 import numpy as np
 from numpy.testing import assert_allclose
 import pytest
 import matplotlib.pyplot as plt
-import tempfile
 
 import hnn_core
-from hnn_core import read_params, CellResponse, Network
-from hnn_core import jones_2009_model, law_2021_model, calcium_model
-from hnn_core.network_models import add_erp_drives_to_jones_model
+from hnn_core import (
+    CellResponse,
+    Network,
+    calcium_model,
+    jones_2009_model,
+    law_2021_model,
+    read_params,
+    simulate_dipole,
+)
+from hnn_core.cells_default import pyramidal, basket
+from hnn_core.network import _create_cell_coords, pick_connection
 from hnn_core.network_builder import NetworkBuilder
-from hnn_core.network import pick_connection
+from hnn_core.network_models import add_erp_drives_to_jones_model
+from hnn_core.params import _short_name
 from hnn_core.viz import plot_dipole
 
 hnn_core_root = op.dirname(hnn_core.__file__)
@@ -94,8 +103,6 @@ def base_network():
 
 
 def test_create_cell_coords():
-    from hnn_core.network import _create_cell_coords
-
     layer_dict = _create_cell_coords(
         n_pyr_x=3, n_pyr_y=3, z_coord=1307.4, inplane_distance=1.0
     )
@@ -111,13 +118,6 @@ def test_create_cell_coords():
 
 
 def test_network_models_mod():
-    from hnn_core.network import Network, _create_cell_coords, pick_connection
-    from hnn_core.cells_default import pyramidal, basket
-    from hnn_core.params import _short_name
-    from hnn_core import simulate_dipole, jones_2009_model, read_params
-    from hnn_core.network_models import add_erp_drives_to_jones_model
-    import numpy as np
-
     params = read_params(params_fname)
 
     # Test default jones model

--- a/hnn_core/tests/test_network.py
+++ b/hnn_core/tests/test_network.py
@@ -117,7 +117,8 @@ def test_create_cell_coords():
     assert len(layer_dict["L5_bottom"]) == 9
 
 
-def test_network_models_mod():
+@pytest.mark.parametrize("mesh_shape", [(2, 2), (2, 3)])
+def test_custom_network_coords(mesh_shape):
     params = read_params(params_fname)
 
     # network with custom cell types and positions (an irregular one)
@@ -126,7 +127,10 @@ def test_network_models_mod():
         "L5_pyramidal": pyramidal(cell_name=_short_name("L5_pyramidal")),
     }
     custom_layer_dict = _create_cell_coords(
-        n_pyr_x=2, n_pyr_y=2, z_coord=1307.4, inplane_distance=1.0
+        n_pyr_x=mesh_shape[0],
+        n_pyr_y=mesh_shape[1],
+        z_coord=1307.4,
+        inplane_distance=1.0,
     )
     custom_pos_dict = {
         "L2_pyramidal": custom_layer_dict["L2_bottom"],
@@ -136,9 +140,12 @@ def test_network_models_mod():
     custom_net = Network(params, pos_dict=custom_pos_dict, cell_types=custom_cell_types)
     assert "L2_pyramidal" in custom_net.cell_types
     assert "L5_pyramidal" in custom_net.cell_types
-    assert len(custom_net.pos_dict["L2_pyramidal"]) == 4
-    assert custom_net.gid_ranges["L2_pyramidal"] == range(0, 4)
-    assert custom_net.gid_ranges["L5_pyramidal"] == range(4, 8)
+    total_mesh_size = mesh_shape[0] * mesh_shape[1]
+    assert len(custom_net.pos_dict["L2_pyramidal"]) == total_mesh_size
+    assert custom_net.gid_ranges["L2_pyramidal"] == range(0, total_mesh_size)
+    assert custom_net.gid_ranges["L5_pyramidal"] == range(
+        total_mesh_size, 2 * total_mesh_size
+    )
 
     # ALL types of drives to test interactions
     spike_data = {

--- a/hnn_core/tests/test_network.py
+++ b/hnn_core/tests/test_network.py
@@ -120,17 +120,6 @@ def test_create_cell_coords():
 def test_network_models_mod():
     params = read_params(params_fname)
 
-    # Test default jones model
-    net_default = jones_2009_model(params)
-    assert len(net_default.pos_dict["L5_pyramidal"]) == 100
-    assert len(net_default.pos_dict["L2_pyramidal"]) == 100
-
-    n_conn_before_drives = len(net_default.connectivity)
-    add_erp_drives_to_jones_model(net_default)
-    for drive_name in ["evdist1", "evprox1", "evprox2"]:
-        assert drive_name in net_default.external_drives
-    assert len(net_default.connectivity) == n_conn_before_drives + 14
-
     # jones_2009_model with different custom mesh_shape
     net_custom_mesh = jones_2009_model(params, mesh_shape=(5, 5))
     assert len(net_custom_mesh.pos_dict["L2_pyramidal"]) == 25
@@ -317,6 +306,8 @@ def test_network_models():
     with pytest.raises(TypeError, match="tstart must be"):
         add_erp_drives_to_jones_model(net=net_default, tstart="invalid_input")
     n_conn = len(net_default.connectivity)
+    for cell_name in ["L5_pyramidal", "L2_pyramidal"]:
+        assert len(net_default.pos_dict[cell_name]) == 100
     add_erp_drives_to_jones_model(net_default)
     for drive_name in ["evdist1", "evprox1", "evprox2"]:
         assert drive_name in net_default.external_drives.keys()

--- a/hnn_core/tests/test_network.py
+++ b/hnn_core/tests/test_network.py
@@ -18,7 +18,7 @@ from hnn_core import (
     read_params,
     simulate_dipole,
 )
-from hnn_core.cells_default import pyramidal, basket
+from hnn_core.cells_default import pyramidal
 from hnn_core.network import _create_cell_coords, pick_connection
 from hnn_core.network_builder import NetworkBuilder
 from hnn_core.network_models import add_erp_drives_to_jones_model
@@ -229,40 +229,6 @@ def test_network_models_mod():
     assert dipole_custom is not None
     assert len(dipole_custom[0].times) > 0
     assert np.all(np.isfinite(dipole_custom[0].data["agg"]))
-
-    # Network with normal expected values (Jones 2009 model values)
-    jones_cell_types = {
-        "L2_pyramidal": pyramidal(cell_name=_short_name("L2_pyramidal")),
-        "L5_pyramidal": pyramidal(cell_name=_short_name("L5_pyramidal")),
-        "L2_basket": basket(cell_name=_short_name("L2_basket")),
-        "L5_basket": basket(cell_name=_short_name("L5_basket")),
-    }
-    jones_layer_dict = _create_cell_coords(
-        n_pyr_x=10, n_pyr_y=10, z_coord=1307.4, inplane_distance=1.0
-    )
-    jones_pos_dict = {
-        "L2_pyramidal": jones_layer_dict["L2_bottom"],
-        "L5_pyramidal": jones_layer_dict["L5_bottom"],
-        "L2_basket": jones_layer_dict["L2_bottom"][
-            :35
-        ],  # Jones model uses 35 basket cells
-        "L5_basket": jones_layer_dict["L5_bottom"][:35],
-        "origin": jones_layer_dict["origin"],
-    }
-    normal_net = Network(params, pos_dict=jones_pos_dict, cell_types=jones_cell_types)
-
-    # Verify it matches expected Jones 2009 structure
-    assert len(normal_net.pos_dict["L2_pyramidal"]) == 100
-    assert len(normal_net.pos_dict["L5_pyramidal"]) == 100
-    assert len(normal_net.pos_dict["L2_basket"]) == 35
-    assert len(normal_net.pos_dict["L5_basket"]) == 35
-
-    # Test simulation with normal values
-    add_erp_drives_to_jones_model(normal_net)
-    dipole_normal = simulate_dipole(normal_net, tstop=50.0, dt=0.5, n_trials=1)
-    assert dipole_normal is not None
-    assert len(dipole_normal[0].times) > 0
-    assert np.all(np.isfinite(dipole_normal[0].data["agg"]))
 
 
 def test_network_models():


### PR DESCRIPTION
Hey @Chetank99 , it took longer than expected but here is my PR to your fork's `hnn-rome` branch. This does the following:

1. Adds an entry for all your work to the What's New list for the next release.
2. Fixes missing or deprecated documentation.
3. Reverts the unused `custom_positions` argument to `jones_2009_model` which will be included in a later Chetan-Chunk.
4. Makes several changes to the new tests, including:
    - Deletes most, but not all, of the `jones_2009_model`-using code in your new test function, because much of the code it was running was already being run and tested in other parts of `test_network.py`. In some cases, the additions you made were added to other, pre-existing test functions that were testing the same code paths.
    - The `_n_pyr_x` etc.-relevant tests were moved into the pre-existing `test_network_mesh`, and/or moved into a new, expanded function `test_network_models_mesh`.
    - Several tests, including your main test function, were parametrized to test different situations.
    - Your main test function was renamed to `test_custom_network_coords` since, due to the above changes, what it does is now more specific.

Now YOU get to do code review on MY changes: if you have issues with my changes, then please let me know in this PR. If not, then you can merge it. If you merge this PR, it will get merged into your fork's `hnn-rome` branch, which will automatically update the code used in https://github.com/jonescompneurolab/hnn-core/pull/1095 . At that point, once it passes testing again, I will merge 1095 into `master` and we'll be done with the first Chetan-Chunk!